### PR TITLE
Suggestion: depend on matplotlib-base instead of matplotlib

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -79,4 +79,4 @@ jobs:
     displayName: Upload package
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-    condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))
+    condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -108,4 +108,4 @@ jobs:
       displayName: Upload package
       env:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-      condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))
+      condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -26,6 +26,14 @@ setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 source run_conda_forge_build_setup
 
+
+# Install the yum requirements defined canonically in the
+# "recipe/yum_requirements.txt" file. After updating that file,
+# run "conda smithy rerender" and this line will be updated
+# automatically.
+/usr/bin/sudo -n yum install -y xorg-x11-server-Xorg
+
+
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ A feedstock is made up of a conda recipe (the instructions on what and how to bu
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
+and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
 packages to the [conda-forge](https://anaconda.org/conda-forge)
 [Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1001
+  number: 1002
   skip: True  # [py<34]
   script: python setup.py install --single-version-externally-managed --record record.txt
 
@@ -23,7 +23,7 @@ requirements:
   run:
     - python
     - numpy
-    - matplotlib
+    - matplotlib-base
     - scipy
     - pandas
     - numexpr

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,0 +1,1 @@
+xorg-x11-server-Xorg


### PR DESCRIPTION
I noticed that this recipe depends on `matplotlib` instead of 
`matplotlib-base`. Unless you need `pyqt`, recipes should depend only on `matplotlib-base`. 
This PR makes this change.
Notes and instructions for merging this PR:
1. Make sure that the recipe can indeed only depend on `matplotlib-base`. 
2. Please merge the PR only after the tests have passed. 
3. Feel free to push to the bot's branch to update this PR if needed. 


If this PR was opened in error or needs to be updated please add the `bot-rerun` label to this PR. The bot will close this PR and schedule another one. If you do not have permissions to add this label, you can use the phrase <code>@<space/>conda-forge-admin, please rerun bot</code> in a PR comment to have the `conda-forge-admin` add it for you.

<sub>This PR was created by the [cf-regro-autotick-bot](https://github.com/regro/cf-scripts).
The **cf-regro-autotick-bot** is a service to automatically track the dependency graph, migrate packages, and propose package version updates for conda-forge. If you would like a local version of this bot, you might consider using [rever](https://regro.github.io/rever-docs/). Rever is a tool for automating software releases and forms the backbone of the bot's conda-forge PRing capability. Rever is both conda (`conda install -c conda-forge rever`) and pip (`pip install re-ver`) installable.
Finally, feel free to drop us a line if there are any [issues](https://github.com/regro/cf-scripts/issues)!
This PR was generated by , please use this URL for debugging</sub>